### PR TITLE
Change nav bar to clearly show it is not part of the application

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -16,6 +16,10 @@ function App() {
           className="navbar-menu is-active"
           style={{ borderBottom: "1px solid lightgray" }}
         >
+          <div className="navbar-item" style={{"fontWeight":"bold"}} >
+            Demo controls:
+          </div>
+
           <Link className="navbar-item" to="/">
             MainPage
           </Link>


### PR DESCRIPTION
Just adds a text label "Demo controls" to make it clear that the nav bar is not part of the application:

<img width="1259" alt="Screen Shot 2020-10-28 at 1 41 26 pm" src="https://user-images.githubusercontent.com/2832256/97386212-48270a80-1923-11eb-99d4-03f22022fcb3.png">

